### PR TITLE
Added support for different drill directions and bugfixes

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -1,7 +1,25 @@
 data:extend({
 {
   type = "custom-input",
-  name = "drill-build-event",
-  key_sequence = "SHIFT + R",
+  name = "drill-build-event-north",
+  key_sequence = "SHIFT + W",
+  consuming = "script-only"
+},
+{
+  type = "custom-input",
+  name = "drill-build-event-west",
+  key_sequence = "SHIFT + A",
+  consuming = "script-only"
+},
+{
+  type = "custom-input",
+  name = "drill-build-event-south",
+  key_sequence = "SHIFT + S",
+  consuming = "script-only"
+},
+{
+  type = "custom-input",
+  name = "drill-build-event-east",
+  key_sequence = "SHIFT + D",
   consuming = "script-only"
 }})

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "AutoDrillBuilder",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "title": "Automatic Drill Builder",
     "author": "regresscheck",
     "contact": "",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,8 @@
 
 This is simple tool that allows you create ghost of drills on ore patch with single hotkey.
 
-Just hover your mouse over ore patch and press Shift+R
+Just hover your mouse over ore patch and press Shift+<WASD direction key> to create drills with belts in the desired direction.
+For example, if you want your belts to go left to right, press Shift+D; for top to bottom, press Shift+S; etc.
 
 # Preview
 


### PR DESCRIPTION
* This changes the current hotkey from `Shift-R` to `Shift-D` (and adds all directions through `Shift-{WASD}`. Should be easy to maintain backwards compatibility to the old "east only" `Shift-R` if you want to.
* Fixed issue when loading mod from existing saves or multiplayer games.
* Bumped version to 0.2.0.

--

Sorry for making a single PR instead of splitting those up.